### PR TITLE
Update Congress of Gamers to Spring Session

### DIFF
--- a/src/events/scripts/data/json/ConventionData.js
+++ b/src/events/scripts/data/json/ConventionData.js
@@ -1,9 +1,10 @@
 export const CONVENTION_1 = {
   id: 1,
-  link: "http://emsps.com/cog/winter/index.html",
-  title: "Congress of Gamers Winter Session",
-  days: ["1/18/2025", "1/19/2025"],
+  link: "http://emsps.com/cog/spring/index.html", // Updated link
+  title: "Congress of Gamers Spring Session",      // Updated title
+  days: ["5/3/2025", "5/4/2025"],
 };
+
 
 export const CONVENTION_2 = {
   id: 2,


### PR DESCRIPTION
This PR updates the event information in `ConventionData.js` by replacing the outdated Winter Session details with the Spring Session information. The changes include:

- "Updated the link to point to the new Spring Session page."

- "Changed the title from "Congress of Gamers Winter Session" to "Congress of Gamers Spring Session"."

- "Adjusted the days array to reflect the new event date(s)."

These updates ensure the event information on https://dmvboardgames.com/ is current and accurate.