### PR TITLE
left aligned elements and UI fix of search day btn in tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,72 +1,69 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="/styles/styles.css" />
-    <link rel="stylesheet" href="/styles/eventListing.css" />
-    <link rel="icon" type="image/png" href="/styles/icon-exemple.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DMV Board Games</title>
 
-    <script type="module" src="/src/events/scripts/data/json/GameRestaurantData.js"></script>
-    <script type="module" src="/src/events/scripts/data/json/GameStoreData.js"></script>
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="/styles/styles.css" />
+  <link rel="stylesheet" href="/styles/eventListing.css" />
+  <link rel="icon" type="image/png" href="/styles/icon-exemple.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DMV Board Games</title>
+
+  <script type="module" src="/src/events/scripts/data/json/GameRestaurantData.js"></script>
+  <script type="module" src="/src/events/scripts/data/json/GameStoreData.js"></script>
 
 
 
 
-    <script type="module" src="/src/events/scripts/data/json/GroupData.js"></script>
-    <script type="module" src="/src/events/scripts/EventSearch.js"></script>
+  <script type="module" src="/src/events/scripts/data/json/GroupData.js"></script>
+  <script type="module" src="/src/events/scripts/EventSearch.js"></script>
 
-    <script type="module" src="src/events/scripts/EventDisplay.js"></script>
-    <script
-      type="module"
-      src="src/events/scripts/EventDisplayContainer.js"
-    ></script>
-  </head>
-  <body>
-    <div id="container">
-      <nav>
-        <a href="/index.html">Home</a>
-        <a href="/designers.html">Local designers</a>
-        <a href="/plans.html">Future plans</a>
-      </nav>
+  <script type="module" src="src/events/scripts/EventDisplay.js"></script>
+  <script type="module" src="src/events/scripts/EventDisplayContainer.js"></script>
+</head>
 
-      <div id="hero-sec">
-        <img
-          src="public/DMV_board_games_site_pic_600.png"
-          alt="DMV Board Games"
-        />
-        <div id="para-wrapper">
+<body>
+  <div id="container">
+    <nav>
+      <a href="/index.html">Home</a>
+      <a href="/designers.html">Local designers</a>
+      <a href="/plans.html">Future plans</a>
+    </nav>
+
+    <div id="hero-sec">
+      <div id="para-wrapper">
         <p>
           This page is a work in progress listing of public board game groups, conventions
           stores, and restaurants in the DMV area. Email
           gulu@createthirdplaces.com to request an update to this list or share
           feedback. All submitted items must information visible on their main website without requiring a login.
-          <p>
-            To request a new feature or view the source code, go
+        <p>
+          To request a new feature or view the source code, go
           <a href="https://github.com/Create-Third-Places/DMVBoardGames">here</a>
-          </p>
+        </p>
         </p>
       </div>
-        
-      </div>
-      <div id="root">
 
-        <div id="jump-to">
-          <p>Click for more info about:</p>
+      <img src="public/DMV_board_games_site_pic_600.png" alt="DMV Board Games" />
+
+    </div>
+    <div id="root">
+
+      <div id="jump-to">
+        <p>Click for more info about:</p>
+        <div id="info-btn-list">
           <a href="#convention-list">Conventions</a>
           <a href="#game-store">Game Stores</a>
           <a href="#game-restaurant-list">Bars And Cafés</a>
         </div>
-        <div id="event-search" class="page-section"></div>
+      </div>
+      <div id="event-search" class="page-section"></div>
 
-        <div data-container="root">
-          <script
-            type="module"
-            src="src/events/scripts/EventDisplayContainer.js"
-          ></script>
-        </div>
+      <div data-container="root">
+        <script type="module" src="src/events/scripts/EventDisplayContainer.js"></script>
       </div>
     </div>
-  </body>
+  </div>
+</body>
+
 </html>

--- a/public/styles/eventListing.css
+++ b/public/styles/eventListing.css
@@ -29,7 +29,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 4rem;
-  justify-content: center;
 }
 
 #search-input-wrapper {
@@ -173,8 +172,12 @@ h3:not(.event h3) {
     text-align: center;
   }
 
-  #search-days {
-    margin-top: 1rem;
+  #search-form {
+    justify-content: center;
+  }
+
+  #search-locations {
+    margin-bottom: 1rem;
   }
 
   .event-group h2 {

--- a/public/styles/styles.css
+++ b/public/styles/styles.css
@@ -85,6 +85,29 @@ nav a:last-child {
   text-wrap: nowrap;
 }
 
+#jump-to {
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  width: 100%;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+#jump-to p {
+  white-space: nowrap;
+}
+
+#info-btn-list {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 15px;
+}
+
+
 #page-info {
   padding-top: 50px;
 }
@@ -99,6 +122,29 @@ nav a:last-child {
   }
   button {
     background-color: #f9f9f9;
+  }
+}
+
+@media (max-width: 768px) {
+  #jump-to {
+    width: fit-content;
+    flex-wrap: wrap;
+  }
+
+  #info-btn-list {
+    width: fit-content;
+    gap: 0;
+  }
+}
+
+@media (max-width: 420px) {
+  #jump-to {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  #info-btn-list {
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
Resolves #200 

1. Left aligned mentioned elements to left and moved logo to right side. The final appearance is

Desktop:

![Screenshot from 2025-04-08 00-39-11](https://github.com/user-attachments/assets/978a18e3-838a-466b-8171-cc04c4b87273)

Mobile:

![Screenshot from 2025-04-08 00-38-43](https://github.com/user-attachments/assets/0e6c7a7e-c05c-4ca5-953d-dfb8a0986392)

2. Fixed a UI bug of "search days" button which was going down 1 rem when on tablet screen:

before:

![Screenshot from 2025-04-08 00-40-57](https://github.com/user-attachments/assets/f18f8140-3ccb-4273-af2f-bb850abaa407)

corrected:

![Screenshot from 2025-04-08 00-41-20](https://github.com/user-attachments/assets/38fa5e2e-a5d5-4caa-9ecf-ca05e0810ce1)
