### PR TITLE
Add  robots.txt for AI crawler protection (Fixes #211)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,103 @@
+# DMV Board Games robots.txt
+# Last updated: 2025-04-10
+
+# TODO: Update sitemap location once generated
+
+# Rate limiting for allowed bots
+Crawl-delay: 10
+
+# =================================
+# AI Language Model & Training Bots
+# =================================
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: Claude-Web
+User-agent: ClaudeBot
+User-agent: anthropic-ai
+User-agent: cohere-ai
+User-agent: cohere-training-data-crawler
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+Disallow: /
+
+# =================================
+# AI Image & Data Collection Bots
+# =================================
+User-agent: ImagesiftBot
+User-agent: img2dataset
+User-agent: Diffbot
+User-agent: AI2Bot
+User-agent: Ai2Bot-Dolma
+User-agent: iaskspider/2.0
+Disallow: /
+
+# =================================
+# Tech Company AI Crawlers
+# =================================
+User-agent: Google-Extended
+User-agent: GoogleOther
+User-agent: GoogleOther-Image
+User-agent: GoogleOther-Video
+User-agent: Amazonbot
+User-agent: Applebot
+User-agent: Applebot-Extended
+User-agent: FacebookBot
+User-agent: Meta-ExternalAgent
+User-agent: Meta-ExternalFetcher
+Disallow: /
+
+# =================================
+# General Data Scrapers
+# =================================
+User-agent: Bytespider
+User-agent: CCBot
+User-agent: Crawlspace
+User-agent: DuckAssistBot
+User-agent: FriendlyCrawler
+User-agent: ICC-Crawler
+User-agent: ISSCyberRiskCrawler
+User-agent: Kangaroo Bot
+User-agent: OAI-SearchBot
+User-agent: omgili
+User-agent: omgilibot
+User-agent: PanguBot
+User-agent: PetalBot
+User-agent: Scrapy
+User-agent: SemrushBot-OCOB
+User-agent: SemrushBot-SWA
+User-agent: Sidetrade indexer bot
+User-agent: Timpibot
+User-agent: VelenPublicWebCrawler
+User-agent: Webzio-Extended
+User-agent: YouBot
+User-agent: Brightbot 1.0
+Disallow: /
+
+# =================================
+# Legitimate Search Engine Access
+# =================================
+
+# Google Search
+User-agent: Googlebot
+Allow: /
+Disallow: /admin/
+
+# Bing
+User-agent: Bingbot
+Allow: /
+Disallow: /admin/
+
+# DuckDuckGo
+User-agent: DuckDuckBot
+Allow: /
+Disallow: /admin/
+
+# Yahoo
+User-agent: Slurp
+Allow: /
+Disallow: /admin/
+
+# All other bots
+User-agent: *
+Allow: /
+Disallow: /admin/


### PR DESCRIPTION
Add robots.txt file to protect against AI data collection while maintaining search engine accessibility. Key changes:

Block 46+ AI crawlers including GPT, Claude, and company-specific bots
Organize rules into categories (Language Models, Data Collection, Tech Companies)
Add rate limiting with crawl-delay directive
Protect admin directory from all crawlers
Allow legitimate search engines (Google, Bing, DuckDuckGo, Yahoo)
Add TODO placeholder for future sitemap implementation